### PR TITLE
fix: revert numpy and opencv_python versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.21.6,<2.0.0
-opencv_python>=4.6.0.66
+numpy>=1.19.5,<3.0.0
+opencv_python>=4.5.1.48
 PyYAML
 onnxruntime
 Pillow


### PR DESCRIPTION
参考rapidocr更新了numpy和opencv的版本要求：[[RapidOCR/python/requirements.txt at main · RapidAI/RapidOCR](https://github.com/RapidAI/RapidOCR/blob/main/python/requirements.txt)](https://github.com/RapidAI/RapidOCR/blob/main/python/requirements.txt)

```python
numpy>=1.19.5,<3.0.0
opencv_python>=4.5.1.48
```

### Related Issue
Fixes #41 